### PR TITLE
Add `rake` task to validate all yaml files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,31 @@
+require "yaml"
+
+task :validate do
+  valid = []
+  errors = []
+
+  yaml_files = Dir.glob(File.join("**", "*.yml"))
+  yaml_files.each do |yaml_file|
+    print "."
+    begin
+      YAML.load_file yaml_file
+      valid << yaml_file
+    rescue Exception => e
+      errors << e
+    end
+  end
+  puts
+  puts
+  puts "Validated #{yaml_files.count} YAML files"
+
+  if errors.any?
+    puts
+    puts "ERRORS in #{errors.size} files:"
+    puts
+    errors.each do |error|
+      puts error
+    end
+  end
+end
+
+task default: :validate


### PR DESCRIPTION
You can run this just run `rake` in the root to validate all yaml

```
$ rake
.......................

Validated 23 YAML files

ERRORS in 9 files:

(modules/COLL-00_Introducing-github.yml): mapping values are not allowed in this context at line 40 column 17
(modules/COLL-01_Exploring-a-repository.yml): mapping values are not allowed in this context at line 93 column 27
(modules/COLL-02_Using-issues.yml): found character that cannot start any token while scanning for the next token at line 24 column 15
(modules/CONT-035_Creating-pull-requests.yml): did not find expected key while parsing a block mapping at line 10 column 5
(modules/CONT-03_Creating-files-platform.yml): did not find expected key while parsing a block mapping at line 5 column 5
(modules/CONT-04_Editing-pull-request-files.yml): did not find expected key while parsing a block mapping at line 10 column 5
(modules/CONT-05_Merging-pull-requests.yml): did not find expected key while parsing a block mapping at line 14 column 5
(modules/CONT-CLI-01_Basic-Configuration.yml): did not find expected '-' indicator while parsing a block collection at line 26 column 9
(modules/CONT-CLI-05_Sync-changes.yml): did not find expected key while parsing a block mapping at line 5 column 5
```
