### PR TITLE
reset --mixed doesn't stage

### DIFF
--- a/modules/CONT-CLI-19_Resetting-history.yml
+++ b/modules/CONT-CLI-19_Resetting-history.yml
@@ -48,7 +48,7 @@ screens:
         - do: "Type git reset HEAD~"
           say: "We can type git reset without any options since --mixed is the default mode for reset, then we tell git where we want to reset to. In this case, the tilde tells git we want to reset to one commit before the current location of HEAD."
         - do: "Type git status"
-          say: "Once again, when we type git status the changes we made in the last commit are sitting in the staging area waiting to be committed."
+          say: "Now, when we type git status the changes we made in the last commit are in Changes not staged for commit. We need to add them to the staging area if we want to commit them."
         - do: "Type git commit -m\"another reset example\""
           say: "Let's go ahead and re-commit these changes again."
       production-notes:


### PR DESCRIPTION
/cc @crichID 

I'm not :100:% on editing the content here -- this might need to be a bigger change than I understand right now, for instance -- but I think the `say` script for `reset --mixed` isn't quite right. 

The script has it that `mixed` and `soft` both wind up with changes in the staging area, but that's the `soft` behavior; `mixed` shouldn't be staging any changes.

I have recorded audio that follows the original script, but I suspect we'll want to re-record when we figure out what it should be saying.
