### PR TITLE
Correct "GitHub to "Git" for CLI topics title

### DIFF
--- a/courses/github-for-developers.yml
+++ b/courses/github-for-developers.yml
@@ -21,7 +21,7 @@ sections:
       - CONT-04_Editing-pull-request-files
       - CONT-05_Merging-pull-requests
   -
-    title: Using GitHub Locally
+    title: Using Git Locally
     description: In this section you will learn how to clone the repository to your desktop and work locally to make changes.
     modules:
       - CONT-CLI-01_Basic-Configuration


### PR DESCRIPTION
Using "GitHub" suggestions command line with the platform. This corrects the misunderstanding by clearly identifying this section as Git-specific.

/cc @crichID 
